### PR TITLE
Avoid using ULOG if NFLOG is present for Cumulus Linux

### DIFF
--- a/src/Linux/hsflowd.h
+++ b/src/Linux/hsflowd.h
@@ -110,8 +110,10 @@ extern "C" {
 #include "regex.h" // for switchport detection
 #define HSP_SWITCHPORT_REGEX "^swp[0-9s]+$"
   // uses ULOG (netlink) channel, so make sure that is enabled:
+#ifndef HSF_NFLOG
 #define HSF_ULOG 1
 #define HSP_DEFAULT_ULOG_GROUP 1
+#endif
   // starting in CL 2.5, uses NFLOG, also defaulting to group==1
 #define HSP_DEFAULT_NFLOG_GROUP 1
 #endif


### PR DESCRIPTION
Starting CumulusLinux 3.x ULOG will no longer be present
in the kernel. If NFLOG is present - CumulusLinux 3.0+ use it;
otherwise revert back to ULOG for CumulusLinux 2.X.