### PR TITLE
Avoid undefined memcpy inputs

### DIFF
--- a/src/SunOS/hsflowd.c
+++ b/src/SunOS/hsflowd.c
@@ -210,7 +210,7 @@ extern "C" {
     truncateOpenFile(sp->f_vmStore);
   }
 
-  uint32_t assignVM_dsIndex(HSP *sp, char *uuid) {
+  uint32_t assignVM_dsIndex(HSP *sp, u_char *uuid) {
     // check in case we saw this one before
     HSPVMStore *vmStore = sp->vmStore;
     for ( ; vmStore != NULL; vmStore = vmStore->nxt) {

--- a/src/SunOS/hsflowd.c
+++ b/src/SunOS/hsflowd.c
@@ -764,10 +764,17 @@ extern "C" {
       myLog(LOG_ERR, "myDNSCB: string too long");
       return;
     }
+
+    // bail out of invalid inputs
+    if ((key == NULL && keyLen != 0) || (val == NULL && valLen != 0)) {
+      myLog(LOG_ERR, "myDNSCB: NULL string of non-zero length.");
+      return;
+    }
+
     // null terminate
-    memcpy(keyBuf, (char *)key, keyLen);
+    if (key) memcpy(keyBuf, (char *)key, keyLen);
     keyBuf[keyLen] = '\0';
-    memcpy(valBuf, (char *)val, valLen);
+    if (val) memcpy(valBuf, (char *)val, valLen);
     valBuf[valLen] = '\0';
 
     if(debug) {


### PR DESCRIPTION
This is similar to a change already in the Linux variant but defends against creating a null terminated garbage string with bad input, either accidental or intentional.  One or the other should be propagated to the other variants.

Tested on the SmartOS branch of the SunOS tree.