### PR TITLE
Add support for building on musl-based systems

### DIFF
--- a/src/Linux/hsflowd.c
+++ b/src/Linux/hsflowd.c
@@ -767,6 +767,7 @@ extern "C" {
   */
 
   static void log_backtrace(int sig, siginfo_t *info) {
+#ifdef HAVE_BACKTRACE
 #define HSP_NUM_BACKTRACE_PTRS 50
     static void *backtracePtrs[HSP_NUM_BACKTRACE_PTRS];
 
@@ -787,6 +788,7 @@ extern "C" {
     // thread info
     EVBus *bus = EVCurrentBus();
     fprintf(f_crash, "current bus: %s\n", (bus ? bus->name : "<none>"));
+#endif
   }
 
   /*_________________---------------------------__________________

--- a/src/Linux/hsflowd.h
+++ b/src/Linux/hsflowd.h
@@ -34,10 +34,13 @@ extern "C" {
 #include <sys/resource.h> // for setrlimit()
 #include <limits.h> // for UINT_MAX
 
-// for signal backtrace
+#if defined(__GLIBC__) || defined(__UCLIBC__)
+// for signal backtrace, if supported by libc
+#define HAVE_BACKTRACE 1
 #include <execinfo.h>
 #include <signal.h>
 #include <ucontext.h>
+#endif
 
 #include <regex.h> // for regex_t
 

--- a/src/Linux/readDiskCounters.c
+++ b/src/Linux/readDiskCounters.c
@@ -11,6 +11,9 @@ extern "C" {
 #include <search.h> // for tfind,tsearch,tsdestroy
 #include <sys/statvfs.h> // for statvfs
 
+// For compability with other libc variants
+typedef int (*comparison_fn_t)(const void*, const void*);
+
 /* It looks like we could read this from "fdisk -l",  so the source
    code to fdisk should probably be consulted to find where it can
    be read off */

--- a/src/Linux/util.h
+++ b/src/Linux/util.h
@@ -12,6 +12,7 @@ extern "C" {
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stddef.h>
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
@@ -25,7 +26,12 @@ extern "C" {
 #include <sys/stat.h>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h> // for PRIu64 etc.
+
+#ifdef __GLIBC__
 #include "malloc.h" // for malloc_stats()
+#else
+#define malloc_stats() {}
+#endif
 
 #include <sys/wait.h>
 #include <ctype.h> // for isspace() etc.


### PR DESCRIPTION
Some libc features are not shared between glibc and musl, such as
backtraces. This patch simply disables those missing features when
compiling on a musl-based system.

See also: issue #13