### PR TITLE
consider SReclaimable memory as "cached"

### DIFF
--- a/src/Linux/readMemoryCounters.c
+++ b/src/Linux/readMemoryCounters.c
@@ -25,6 +25,7 @@ extern "C" {
 
     procFile= fopen("/proc/meminfo", "r");
     if(procFile) {
+      uint64_t sreclaimable = 0;
       while(fgets(line, MAX_PROC_LINE_CHARS, procFile)) {
 	if(sscanf(line, "%s %"SCNu64"", var, &val64) == 2) {
 	  gotData = YES;
@@ -34,8 +35,10 @@ extern "C" {
 	  else if(strcmp(var, "Cached:") == 0) mem->mem_cached = val64 * 1024;
 	  else if(strcmp(var, "SwapTotal:") == 0) mem->swap_total = val64 * 1024;
 	  else if(strcmp(var, "SwapFree:") == 0) mem->swap_free = val64 * 1024;
+	  else if(strcmp(var, "SReclaimable:") == 0) sreclaimable = val64 * 1024;
 	}
       }
+      mem->mem_cached += sreclaimable;
       fclose(procFile);
     }
 


### PR DESCRIPTION
Linux caches slab objects, but this doesn't show up in the "Cached" line
of /proc/meminfo. It shows up as SReclaimable instead. The procps-ng
code now takes this into account, so "free" and "top" will show more
memory cached and hence available.

A more thorough discussion is here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=565518
https://gitlab.com/procps-ng/procps/commit/6cb75efef85f735b72e6c96f197f358f511f8ed9

Note that the above procps-ng change is incorrect! It gets fixed here:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=799716
https://gitlab.com/procps-ng/procps/commit/05d751c4f076a2f0118b914c5e51cfbb4762ad8e

In this patch, SReclaimable is added as a separate step after parsing
the entire file because it seems unwise to assume that /proc/meminfo is
in any particular order.

Quite old Linux kernels do not include SReclaimable, so this patch has
no effect on them.

This patch is written to not assume that /proc/meminfo lists data in any
particular order.