### PR TITLE
Make switching between ipv4 and ipv6 for interface adaptors

### DIFF
--- a/src/Linux/readInterfaces.c
+++ b/src/Linux/readInterfaces.c
@@ -870,10 +870,11 @@ extern "C" {
 	if (ifr.ifr_addr.sa_family == AF_INET) {
 	  struct sockaddr_in *s = (struct sockaddr_in *)&ifr.ifr_addr;
 	  // IP addr is now s->sin_addr
-	  adaptorNIO->ipAddr.type = SFLADDRESSTYPE_IP_V4;
-	  adaptorNIO->ipAddr.address.ip_v4.addr = s->sin_addr.s_addr;
-	  // add to localIP hash too
-	  addLocalIP(newLocalIP, &adaptorNIO->ipAddr, adaptor->deviceName);
+	  SFLAddress ipAddr;
+	  ipAddr.type = SFLADDRESSTYPE_IP_V4;
+	  ipAddr.address.ip_v4.addr = s->sin_addr.s_addr;
+	  // add to localIP hash
+	  addLocalIP(newLocalIP, &ipAddr, adaptor->deviceName);
 	}
 	//else if (ifr.ifr_addr.sa_family == AF_INET6) {
 	// not sure this ever happens - on a linux system IPv6 addresses


### PR DESCRIPTION
* Select agent address in cases, when agentDevice is set
  in current configuration or in config file, according
  to address priority ranking.
  The mechanism is required for cases, when the IPv4
  address of the interface has deleted.
  The change is only for Linux platform.

Signed-off-by: Maksym Belei <Maksym_Belei@jabil.com>

**- What I did**
There is the related issue in SONiC community: https://github.com/Azure/sonic-buildimage/issues/6951
According to the issue, hsflowd should switch sflow agent to IPv6, if IPv4 is not present for the interface, or, it was deleted from the system. With the changes, hsflowd will switch the agent to IPv6 address if IPv4 no more available and will back to IPv4 if it will be added to the system. The switching is being performed according to address priority ranking.

**- How I did it**
By crossing around all the records, related to required network interface, inside both localIP and localIP6 containers. All the found records is being compared and selected the most priority address. So, if the IPv4 address will be deleted from the system, the next in priority rank address will be selected.

**- How to verify it**
Please, take a look on steps to reproduce in https://github.com/Azure/sonic-buildimage/issues/6951. Sflow agent should switch between IPv4 and IPv6 while removing or adding a IPv4 entry for the related network interface.

**- Additional information**
As I have only device with SONiC for testing, I have made the changes inside host-sflow only for Linux platform. Probably, the same changes could be desirable for other platforms