### PR TITLE
bugfix: build error due to missing file in argument

### DIFF
--- a/src/json/Makefile
+++ b/src/json/Makefile
@@ -98,7 +98,7 @@ $(CJSON_SHARED_VERSION): $(CJSON_OBJ)
 	$(CC) -shared -o $@ $< $(CJSON_SO_LDFLAG) $(LDFLAGS)
 #cJSON_Utils
 $(UTILS_SHARED_VERSION): $(UTILS_OBJ)
-	$(CC) -shared -o $@ $< $(UTILS_SO_LDFLAG) $(LDFLAGS)
+	$(CC) -shared -o $@ $(CJSON_OBJ) $< $(UTILS_SO_LDFLAG) $(LDFLAGS)
 
 #objects
 #cJSON


### PR DESCRIPTION
Hello,
I did not find an indication for PRs so not sure about the good practices here.
When trying to build on a Mac, it seems it is missing `cJSON.o` and I am getting the following error
```bash
$ make
[...]
cc -shared -o libcjson.dylib.1.7.12 cJSON.o ""
ln -s libcjson.dylib.1.7.12 libcjson.dylib.1
ln -s libcjson.dylib.1 libcjson.dylib
cc -c -fPIC -std=c89 -pedantic -Wall -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes -Wstrict-overflow=2 -Wcast-qual -Wc++-compat -Wundef -Wswitch-default -Wconversion -fstack-protector cJSON_Utils.c
cc -shared -o libcjson_utils.dylib.1.7.12 cJSON_Utils.o ""
Undefined symbols for architecture x86_64:
  "_cJSON_AddItemToArray", referenced from:
      _apply_patch in cJSON_Utils.o
      _compose_patch in cJSON_Utils.o
      _insert_item_in_array in cJSON_Utils.o
  "_cJSON_AddItemToObject", referenced from:
      _apply_patch in cJSON_Utils.o
      _compose_patch in cJSON_Utils.o
      _merge_patch in cJSON_Utils.o
      _generate_merge_patch in cJSON_Utils.o
  "_cJSON_CreateArray", referenced from:
      _cJSONUtils_GeneratePatches in cJSON_Utils.o
      _cJSONUtils_GeneratePatchesCaseSensitive in cJSON_Utils.o
  "_cJSON_CreateNull", referenced from:
      _generate_merge_patch in cJSON_Utils.o
  "_cJSON_CreateObject", referenced from:
      _compose_patch in cJSON_Utils.o
      _merge_patch in cJSON_Utils.o
      _generate_merge_patch in cJSON_Utils.o
  "_cJSON_CreateString", referenced from:
      _compose_patch in cJSON_Utils.o
  "_cJSON_Delete", referenced from:
      _apply_patch in cJSON_Utils.o
      _merge_patch in cJSON_Utils.o
      _generate_merge_patch in cJSON_Utils.o
      _overwrite_item in cJSON_Utils.o
  "_cJSON_DeleteItemFromObject", referenced from:
      _apply_patch in cJSON_Utils.o
      _merge_patch in cJSON_Utils.o
  "_cJSON_DeleteItemFromObjectCaseSensitive", referenced from:
      _apply_patch in cJSON_Utils.o
      _merge_patch in cJSON_Utils.o
  "_cJSON_DetachItemFromObject", referenced from:
      _merge_patch in cJSON_Utils.o
      _detach_path in cJSON_Utils.o
  "_cJSON_DetachItemFromObjectCaseSensitive", referenced from:
      _merge_patch in cJSON_Utils.o
  "_cJSON_Duplicate", referenced from:
      _apply_patch in cJSON_Utils.o
      _compose_patch in cJSON_Utils.o
      _merge_patch in cJSON_Utils.o
      _generate_merge_patch in cJSON_Utils.o
  "_cJSON_GetObjectItem", referenced from:
      _get_object_item in cJSON_Utils.o
  "_cJSON_GetObjectItemCaseSensitive", referenced from:
      _get_object_item in cJSON_Utils.o
  "_cJSON_IsArray", referenced from:
      _cJSONUtils_FindPointerFromObjectTo in cJSON_Utils.o
      _get_item_from_pointer in cJSON_Utils.o
      _cJSONUtils_ApplyPatches in cJSON_Utils.o
      _apply_patch in cJSON_Utils.o
      _cJSONUtils_ApplyPatchesCaseSensitive in cJSON_Utils.o
      _detach_path in cJSON_Utils.o
  "_cJSON_IsNull", referenced from:
      _merge_patch in cJSON_Utils.o
  "_cJSON_IsObject", referenced from:
      _cJSONUtils_FindPointerFromObjectTo in cJSON_Utils.o
      _get_item_from_pointer in cJSON_Utils.o
      _apply_patch in cJSON_Utils.o
      _merge_patch in cJSON_Utils.o
      _generate_merge_patch in cJSON_Utils.o
      _detach_path in cJSON_Utils.o
  "_cJSON_IsString", referenced from:
      _apply_patch in cJSON_Utils.o
      _decode_patch_operation in cJSON_Utils.o
  "_cJSON_free", referenced from:
      _cJSONUtils_FindPointerFromObjectTo in cJSON_Utils.o
      _apply_patch in cJSON_Utils.o
      _compose_patch in cJSON_Utils.o
      _create_patches in cJSON_Utils.o
      _overwrite_item in cJSON_Utils.o
      _detach_path in cJSON_Utils.o
  "_cJSON_malloc", referenced from:
      _cJSONUtils_FindPointerFromObjectTo in cJSON_Utils.o
      _cJSONUtils_strdup in cJSON_Utils.o
      _compose_patch in cJSON_Utils.o
      _create_patches in cJSON_Utils.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [libcjson_utils.dylib.1.7.12] Error 1
make: *** [hsflowd] Error 2
```
To fix, it needs this:
```
cc -shared -o libcjson_utils.dylib.1.7.12 cJSON.o cJSON_Utils.o ""
```
I edited the Makefile in this PR (not sure how clean), compilation now works and also on Linux.