### PR TITLE
Update_osindex_to_Support_Port_breakout

### DIFF
--- a/src/Linux/mod_sonic.c
+++ b/src/Linux/mod_sonic.c
@@ -1106,6 +1106,8 @@ extern "C" {
 	  else if(!my_strequal(prt->oid, p_oid->str)) {
 	    // OID changed under our feet
 	    setStr(&prt->oid, p_oid->str);
+	    // Reset the port osIndex to update for the new values
+	    prt->osIndex = HSP_SONIC_IFINDEX_UNDEFINED;
 	    signalCounterDiscontinuity(mod, prt);
 	  }
 	  if(prt->osIndex == HSP_SONIC_IFINDEX_UNDEFINED) {


### PR DESCRIPTION
Issue:
   When the user updates the interface for the dynamic port breakout with global sFlow enable, hsflowd is not updated with the Linux index for the port which is available across the breakout.

Explanation:

sonic(config)# do show interface breakout
1/11  1x100G         Completed     Ethernet40

After breakout,
sonic(config)# do show interface breakout
1/11  4x10G          Completed       Ethernet40
                                                      Ethernet41
                                                      Ethernet42
                                                      Ethernet43

Index of Ethernet41,42,43 are updated properly as it is updated as new ports. But for the Ethernet40 it is not updated, and it is still with the old Linux index.

Sample UT Log:

dbg1:sonic db_portNamesCB: reply=array(146)
dbg1:sonic db_portNamesCB: new port Ethernet41 -> oid:0x1000000000f33
dbg1:sonic db_portNamesCB: new port Ethernet42 -> oid:0x1000000000f5c
dbg1:sonic db_portNamesCB: new port Ethernet43 -> oid:0x1000000000f85
dbg1:sonic db_select(6)
dbg1:sonic db_select returned 0
dbg1:sonic db_getIfIndexMap()
dbg1:sonic db_getIfIndexMap() returned 0
dbg2:mS=128172 agentCB_sendPkt() sending datagram: 112
dbg1:sonic db_selectCB: reply=status(0)="OK"
dbg1:sonic db_ifIndexMapCB: reply=array(4)
dbg1:sonic db_ifIndexMapCB: index=string(2)="44"
dbg1:sonic db_ifIndexMapCB: ifindex=string(3)="985"
dbg1:setAdaptorAlias(MOD_SONIC): NULL alias == Ethernet43 (changed=YES)
dbg1:setAdaptorSelectionPriority(MOD_SONIC): Ethernet43 0 -> 44 (changed=YES)
dbg1:sonic db_getIfIndexMap()
dbg1:sonic db_getIfIndexMap() returned 0
dbg1:sonic db_ifIndexMapCB: reply=array(4)
dbg1:sonic db_ifIndexMapCB: index=string(2)="43"
dbg1:sonic db_ifIndexMapCB: ifindex=string(3)="984"
dbg1:setAdaptorAlias(MOD_SONIC): NULL alias == Ethernet42 (changed=YES)
dbg1:setAdaptorSelectionPriority(MOD_SONIC): Ethernet42 0 -> 43 (changed=YES)
dbg1:sonic db_getIfIndexMap()
dbg1:sonic db_getIfIndexMap() returned 0
dbg1:sonic db_ifIndexMapCB: reply=array(4)
dbg1:sonic db_ifIndexMapCB: index=string(2)="42"
dbg1:sonic db_ifIndexMapCB: ifindex=string(3)="983"
dbg1:setAdaptorAlias(MOD_SONIC): NULL alias == Ethernet41 (changed=YES)
dbg1:setAdaptorSelectionPriority(MOD_SONIC): Ethernet41 0 -> 42 (changed=YES)
dbg1:sonic db_getIfIndexMap()
dbg1:sonic db_getIfIndexMap() returned 0
dbg1:sonic db_ifIndexMapCB: reply=array(4)
dbg1:sonic db_ifIndexMapCB: index=string(2)="41"
dbg1:sonic db_ifIndexMapCB: ifindex=string(3)="982"
dbg1:setAdaptorAlias(MOD_SONIC): NULL alias == Ethernet40 (changed=YES)
dbg1:setAdaptorSelectionPriority(MOD_SONIC): Ethernet40 0 -> 41 (changed=YES)
