### PR TITLE
remove extra space in log message

### DIFF
--- a/src/AIX/hsflowconfig.c
+++ b/src/AIX/hsflowconfig.c
@@ -824,7 +824,7 @@ extern int debug;
       for(HSPCollector *coll = sp->sFlow->sFlowSettings_file->collectors; coll; coll = coll->nxt) {
 	//////////////////////// collector /////////////////////////
 	if(coll->ipAddr.type == 0) {
-	  myLog(LOG_ERR, "parse error in %s : collector  has no IP", sp->configFile);
+	  myLog(LOG_ERR, "parse error in %s : collector has no IP", sp->configFile);
 	  parseOK = NO;
 	}
       }

--- a/src/Darwin/hsflowconfig.c
+++ b/src/Darwin/hsflowconfig.c
@@ -1443,7 +1443,7 @@ extern "C" {
       for(HSPCollector *coll = sp->sFlowSettings_file->collectors; coll; coll = coll->nxt) {
 	//////////////////////// collector /////////////////////////
 	if(coll->ipAddr.type == 0) {
-	  myLog(LOG_ERR, "parse error in %s : collector  has no IP", sp->configFile);
+	  myLog(LOG_ERR, "parse error in %s : collector has no IP", sp->configFile);
 	  parseOK = NO;
 	}
       }

--- a/src/FreeBSD/hsflowconfig.c
+++ b/src/FreeBSD/hsflowconfig.c
@@ -642,7 +642,7 @@ extern int debug;
       for(HSPCollector *coll = sp->sFlow->sFlowSettings_file->collectors; coll; coll = coll->nxt) {
 	//////////////////////// collector /////////////////////////
 	if(coll->ipAddr.type == 0) {
-	  myLog(LOG_ERR, "parse error in %s : collector  has no IP", sp->configFile);
+	  myLog(LOG_ERR, "parse error in %s : collector has no IP", sp->configFile);
 	  parseOK = NO;
 	}
       }

--- a/src/Linux/hsflowconfig.c
+++ b/src/Linux/hsflowconfig.c
@@ -2206,7 +2206,7 @@ extern "C" {
       for(HSPCollector *coll = sp->sFlowSettings_file->collectors; coll; coll = coll->nxt) {
 	//////////////////////// collector /////////////////////////
 	if(coll->ipAddr.type == 0) {
-	  myLog(LOG_ERR, "parse error in %s : collector  has no IP", sp->configFile);
+	  myLog(LOG_ERR, "parse error in %s : collector has no IP", sp->configFile);
 	  parseOK = NO;
 	}
       }

--- a/src/SunOS/hsflowconfig.c
+++ b/src/SunOS/hsflowconfig.c
@@ -795,7 +795,7 @@ extern "C" {
       for(HSPCollector *coll = sp->sFlow->sFlowSettings_file->collectors; coll; coll = coll->nxt) {
 	//////////////////////// collector /////////////////////////
 	if(coll->ipAddr.type == 0) {
-	  myLog(LOG_ERR, "parse error in %s : collector  has no IP", sp->configFile);
+	  myLog(LOG_ERR, "parse error in %s : collector has no IP", sp->configFile);
 	  parseOK = NO;
 	}
       }


### PR DESCRIPTION
Hello maintainers,

This is my first ever PR to the repo; your feedback is much appreciated.

I noticed there is an extra space in a log message:
```
s/collector  has/collector has/
```