### PR TITLE
Fix Debian 12 docker build, add Debian 13

### DIFF
--- a/docker_build/debian12/Dockerfile
+++ b/docker_build/debian12/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:bookworm
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
       build-essential \
+      clang \
       git-all \
       libpcap-dev \
       libvirt-dev \
@@ -13,6 +14,3 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
 RUN mkdir /packages && chown 777 /packages
 COPY build_hsflowd /root/build_hsflowd
 ENTRYPOINT ["/root/build_hsflowd"]
-
-
-

--- a/docker_build/debian13/Dockerfile
+++ b/docker_build/debian13/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:trixie
+RUN apt-get -y update && apt-get install -y --no-install-recommends \
+      build-essential \
+      clang \
+      git-all \
+      libpcap-dev \
+      libvirt-dev \
+      libnfnetlink-dev \
+      libxml2-dev \
+      libssl-dev \
+      libdbus-1-dev \
+      uuid-dev \
+      dmidecode
+RUN mkdir /packages && chown 777 /packages
+COPY build_hsflowd /root/build_hsflowd
+ENTRYPOINT ["/root/build_hsflowd"]

--- a/docker_build/debian13/build_hsflowd
+++ b/docker_build/debian13/build_hsflowd
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "build_hsflowd on platform:  $1"
+
+git clone https://github.com/sflow/host-sflow \
+&& cd host-sflow \
+&& make deb FEATURES="NFLOG PCAP TCP DOCKER KVM OVS DBUS SYSTEMD DROPMON PSAMPLE DENT CONTAINERD"
+
+for deb in `ls *.deb`; do cp "$deb" "/packages/${deb/hsflowd/hsflowd-$1}"; done
+echo ""
+echo "files in /packages:"
+ls -l /packages
+


### PR DESCRIPTION
This adds clang to the Debian 12 Dockerfile to fix the build, and adds Debian 13 to the `docker_build/` folder