### PR TITLE
Fix Debian 12 build and add Debian 13

### DIFF
--- a/docker_build/debian12/Dockerfile
+++ b/docker_build/debian12/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:bookworm
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
       build-essential \
+      clang \
       git-all \
       libpcap-dev \
       libvirt-dev \
@@ -13,6 +14,3 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
 RUN mkdir /packages && chown 777 /packages
 COPY build_hsflowd /root/build_hsflowd
 ENTRYPOINT ["/root/build_hsflowd"]
-
-
-

--- a/docker_build/debian13/Dockerfile
+++ b/docker_build/debian13/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:trixie
+RUN apt-get -y update && apt-get install -y --no-install-recommends \
+      build-essential \
+      clang \
+      git-all \
+      libpcap-dev \
+      libvirt-dev \
+      libnfnetlink-dev \
+      libxml2-dev \
+      libssl-dev \
+      libdbus-1-dev \
+      uuid-dev \
+      dmidecode
+RUN mkdir /packages && chown 777 /packages
+COPY build_hsflowd /root/build_hsflowd
+ENTRYPOINT ["/root/build_hsflowd"]

--- a/docker_build/debian13/Dockerfile
+++ b/docker_build/debian13/Dockerfile
@@ -2,7 +2,9 @@ FROM debian:trixie
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
       build-essential \
       clang \
+      bpftool \
       git-all \
+      libbpf-dev \
       libpcap-dev \
       libvirt-dev \
       libnfnetlink-dev \

--- a/docker_build/debian13/build_hsflowd
+++ b/docker_build/debian13/build_hsflowd
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "build_hsflowd on platform:  $1"
+
+git clone https://github.com/sflow/host-sflow \
+&& cd host-sflow \
+&& make deb FEATURES="NFLOG PCAP TCP DOCKER KVM OVS DBUS SYSTEMD DROPMON PSAMPLE DENT CONTAINERD"
+
+for deb in `ls *.deb`; do cp "$deb" "/packages/${deb/hsflowd/hsflowd-$1}"; done
+echo ""
+echo "files in /packages:"
+ls -l /packages
+

--- a/docker_build/debian13/build_hsflowd
+++ b/docker_build/debian13/build_hsflowd
@@ -1,12 +1,15 @@
 #!/bin/bash
 echo "build_hsflowd on platform:  $1"
 
+# clang seems to be looking for c headers (e.g. asm/types.h) in /usr/include/asm, which does not exist in 
+# the Debian 13/Trixie image.
+ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/asm
+
 git clone https://github.com/sflow/host-sflow \
 && cd host-sflow \
-&& make deb FEATURES="NFLOG PCAP TCP DOCKER KVM OVS DBUS SYSTEMD DROPMON PSAMPLE DENT CONTAINERD"
+&& make deb FEATURES="NFLOG PCAP TCP DOCKER KVM OVS DBUS SYSTEMD DROPMON PSAMPLE DENT CONTAINERD EPCAP"
 
 for deb in `ls *.deb`; do cp "$deb" "/packages/${deb/hsflowd/hsflowd-$1}"; done
 echo ""
 echo "files in /packages:"
 ls -l /packages
-

--- a/docker_build/debian13/build_hsflowd
+++ b/docker_build/debian13/build_hsflowd
@@ -3,7 +3,7 @@ echo "build_hsflowd on platform:  $1"
 
 # clang seems to be looking for c headers (e.g. asm/types.h) in /usr/include/asm, which does not exist in 
 # the Debian 13/Trixie image.
-ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/asm
+ln -s /usr/include/`dpkg-architecture -qDEB_HOST_MULTIARCH`/asm /usr/include/asm
 
 git clone https://github.com/sflow/host-sflow \
 && cd host-sflow \


### PR DESCRIPTION
This adds clang to the Debian 12 Dockerfile to fix the build and adds Debian13 to the `docker_build/` folder